### PR TITLE
Fix version handling

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,0 @@
-1-SNAPSHOT

--- a/lib/iyzipay/version.rb
+++ b/lib/iyzipay/version.rb
@@ -1,3 +1,3 @@
 module Iyzipay
-  VERSION = IO.read("VERSION")
+  VERSION = "1-SNAPSHOT"
 end


### PR DESCRIPTION
After requiring the gem in a Rails environment, its throwing the following error because it's path is relative;

```
Errno::ENOENT: No such file or directory @ rb_sysopen - VERSION
        from /home/mehmet/.rvm/gems/ruby-2.2.3@hws/gems/iyzipay-1.0.31/lib/iyzipay/version.rb:2:in `read'
        from /home/mehmet/.rvm/gems/ruby-2.2.3@hws/gems/iyzipay-1.0.31/lib/iyzipay/version.rb:2:in `<module:Iyzipay>'
        from /home/mehmet/.rvm/gems/ruby-2.2.3@hws/gems/iyzipay-1.0.31/lib/iyzipay/version.rb:1:in `<top (required)>'
...
```

Altough, reading version from a file is not a common practice for ruby gems. 
