### PR TITLE
RestClient Update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'rest-client', '~> 1.8.0'
+gem 'rest-client'
 gem 'rack', '1.6.4'
 
 group :development, :local_development do

--- a/iyzipay.gemspec
+++ b/iyzipay.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage              = 'http://rubygems.org/gems/iyzipay'
   s.license               = 'MIT'
 
-  s.add_runtime_dependency 'rest-client', '~> 1.8', '>= 1.8.0'
+  s.add_runtime_dependency 'rest-client'
   s.add_development_dependency 'rspec', '~> 3.3.0'
   s.add_development_dependency 'rspec-rails', '~> 3.3.0'
 


### PR DESCRIPTION
I have removed the specific version dependency on rest-client gem as version 2.0 strongly suggested to be used. 