### PR TITLE
Fix gemspec dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,5 @@
 source 'http://rubygems.org'
 
-gem 'rest-client', '~> 2.0'
-gem 'rack', '1.6.4'
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-group :development, :local_development do
-  gem 'rspec'
-  gem 'rspec-rails'
-  gem 'nokogiri', '1.8.1'
-end
+gemspec

--- a/iyzipay.gemspec
+++ b/iyzipay.gemspec
@@ -15,9 +15,11 @@ Gem::Specification.new do |s|
   s.homepage              = 'http://rubygems.org/gems/iyzipay'
   s.license               = 'MIT'
 
-  s.add_runtime_dependency 'rest-client', '~> 1.8', '>= 1.8.0'
+  s.add_runtime_dependency 'rest-client', '~> 2.0'
+  s.add_runtime_dependency 'rack', '~> 1.6'
   s.add_development_dependency 'rspec', '~> 3.3.0'
   s.add_development_dependency 'rspec-rails', '~> 3.3.0'
+  s.add_development_dependency 'nokogiri', '1.8.1'
 
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
Hi!

You've tried to solve the issue https://github.com/iyzico/iyzipay-ruby/issues/15 by putting several dependencies into the Gemfile. But that's a bit broken for now cause you've occasionally left some of them unchanged in your gemspec file.

I suggest you do not to use Gemfile for the project dependencies at all. They will be included there from the gemspec anyway when the bundler will processes the gem.

Take a look at this page in documentation plz: http://bundler.io/v1.16/guides/creating_gem.html That's what I'm talking about:

> Gemfile: Used to manage gem dependencies for our library’s development. This file contains a gemspec line meaning that Bundler will include dependencies specified in foodie.gemspec too. It’s best practice to specify all the gems that our library depends on in the gemspec.
